### PR TITLE
Add configuration options and defaults

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -10,6 +10,10 @@ import yaml
 
 app = Flask(__name__)
 
+default_settings = {
+        "host": "0.0.0.0",
+        "port": "5000"
+    }
 
 @app.route("/")
 def hello():
@@ -146,8 +150,14 @@ def api_search():
 
 
 if __name__ == "__main__":
+    settings = {}
+
+    # load default settings
+    settings.update(default_settings)
+
+    # load settings from config file
     with open("./static/config.yaml", "r") as f:
-        settings = yaml.safe_load(f)
+        settings.update(yaml.safe_load(f))
 
     country_codes = set(
         [country.alpha_2 for country in pycountry.countries]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -155,6 +155,6 @@ if __name__ == "__main__":
 
     app.run(
         debug=True,
-        port=5000,
+        port=settings["port"],
         host=settings["host"]
     )

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -7,6 +7,7 @@ from flask import (
 from simplejustwatchapi import justwatch
 import pycountry
 import yaml
+import os
 
 app = Flask(__name__)
 
@@ -158,6 +159,12 @@ if __name__ == "__main__":
     # load settings from config file
     with open("./static/config.yaml", "r") as f:
         settings.update(yaml.safe_load(f))
+
+    # override settings by environment variables, if exists
+    if 'DIONYSUS_HOST' in os.environ:
+        settings["host"] = os.environ['DIONYSUS_HOST']
+    if 'DIONYSUS_PORT' in os.environ:
+        settings["port"] = os.environ['DIONYSUS_PORT']
 
     country_codes = set(
         [country.alpha_2 for country in pycountry.countries]


### PR DESCRIPTION
My main focus with this pull request was adding an option to change the port,
but while I was at it, I also made sure to add some settings defaults and the
possibility to override configuration by environment variables.

- The `host` option in `config.yaml` is now optional and defaults to "0.0.0.0"
  if not set.
- Added an optional `port` option to `config.yaml` which defaults to "5000" if
  not set.
- Added environment variables `DIONYSUS_HOST` and `DIONYSUS_PORT` which may be
  used to override the configuration from `config.yaml` if so desired.
